### PR TITLE
fix: #3330 异步加载字典导致偶尔出现字典未翻译的问题修复，改为async/await等待加载完成后，才继续执行后续代码

### DIFF
--- a/src/components/jeecg/JVxeTable/components/JVxeTable.js
+++ b/src/components/jeecg/JVxeTable/components/JVxeTable.js
@@ -338,7 +338,7 @@ export default {
     },
     columns: {
       immediate: true,
-      handler(columns) {
+      async handler(columns) {
         //获取不需要显示列
         this.loadExcludeCode()
         let innerColumns = []
@@ -351,9 +351,9 @@ export default {
           this.statistics.average = []
 
           // 处理成vxe可识别的columns
-          columns.forEach(column => {
+          for (const column of columns) {
             if(this.excludeCode.indexOf(column.key)>=0){
-              return false
+              continue
             }
             let col = {...column}
             let {type} = col
@@ -388,7 +388,7 @@ export default {
               col[renderName] = renderOptions
               // 处理字典
               if (col.dictCode) {
-                this._loadDictConcatToOptions(col)
+                await this._loadDictConcatToOptions(col)
               }
               // 处理校验
               if (col.validateRules) {
@@ -437,7 +437,7 @@ export default {
               }
               innerColumns.push(col)
             }
-          })
+          }
         }
         // 判断是否开启了序号
         if (rowNumber) {
@@ -794,7 +794,7 @@ export default {
           }
         })
       })
-      // 【issues/3828】数据更新后，重新计算统计列 
+      // 【issues/3828】数据更新后，重新计算统计列
       if (updated && this.statistics.has) {
         this.$nextTick(async () => {
           let {xTable} = this.$refs.vxe.$refs;
@@ -1061,21 +1061,25 @@ export default {
     },
 
     /** 加载数据字典并合并到 options */
-    _loadDictConcatToOptions(column) {
-      initDictOptions(column.dictCode).then((res) => {
-        if (res.success) {
-          let newOptions = (column.options || [])// .concat(res.result)
-          res.result.forEach(item => {
-            // 过滤重复数据
-            for (let option of newOptions) if (option.value === item.value) return
-            newOptions.push(item)
-          })
-          this.$set(column, 'options', newOptions)
-        } else {
-          console.group(`JVxeTable 查询字典(${column.dictCode})发生异常`)
-          console.warn(res.message)
-          console.groupEnd()
-        }
+    async _loadDictConcatToOptions(column) {
+      return new Promise((resolve, reject) => {
+        initDictOptions(column.dictCode).then((res) => {
+          if (res.success) {
+            let newOptions = (column.options || [])// .concat(res.result)
+            res.result.forEach(item => {
+              // 过滤重复数据
+              for (let option of newOptions) if (option.value === item.value) return
+              newOptions.push(item)
+            })
+            this.$set(column, 'options', newOptions)
+            resolve()
+          } else {
+            console.group(`JVxeTable 查询字典(${column.dictCode})发生异常`)
+            console.warn(res.message)
+            console.groupEnd()
+            reject()
+          }
+        })
       })
     },
     //options自定义赋值 刷新

--- a/src/components/jeecg/JVxeTable/components/JVxeTable.js
+++ b/src/components/jeecg/JVxeTable/components/JVxeTable.js
@@ -108,6 +108,8 @@ export default {
       caseId: `_j-vxe-${randomString(8)}_`,
       // 内置columns
       innerColumns: [],
+      // 新增flag：列的字典数据是异步加载的，如果设置了默认子表添加行addDefaultRowNum，列字典还没加载完成时，就会执行，导致出错。如果列数据加载完成，则标记为true
+      renderFinish: false,
       // 内置 EditRules
       innerEditRules: [],
       // 记录滚动条位置
@@ -491,6 +493,7 @@ export default {
 
         this.innerColumns = innerColumns
         this.innerEditRules = innerEditRules
+        this.renderFinish = true
       }
     },
     // watch linkageConfig

--- a/src/components/jeecg/JVxeTable/utils/vxeUtils.js
+++ b/src/components/jeecg/JVxeTable/utils/vxeUtils.js
@@ -13,7 +13,9 @@ export function getRefPromise(vm, name) {
   return new Promise((resolve) => {
     (function next() {
       let ref = vm.$refs[name]
-      if (ref) {
+      // 部分组件存在异步方法，新增了一个flag，如果执行完成则将flag置为true
+      // 如果有flag字段，则必须为true，如果没有flag字段则不必判断
+      if (ref && (!ref.hasOwnProperty('renderFinish') || ref.renderFinish) ) {
         resolve(ref)
       } else {
         setTimeout(() => {


### PR DESCRIPTION
[修复偶尔出现的字典未翻译的问题](https://github.com/jeecgboot/jeecg-boot/issues/3330)
原来的watch方法中，存在调用接口来获取数据，是异步操作，如果接口响应较慢，就会出现字典未翻译的情况。
将上述代码改为async/await方式，等待接口返回数据之后再进行后续操作。

由于watch改为了async函数，会导致 "子表默认新增空数据" 功能异常
具体表现为，列数据还未加载成功时，就执行了 "子表默认新增空数据" 操作。会报错，自动产生的列序号、字段默认值等信息无法自动填充。
因此，新增了一个flag字段，用来表示该组件已加载完成，可以进行后续操作了。
getRefPromise获取ref时，会等待组件加载完成后，才进行后续操作。